### PR TITLE
Ui touchup

### DIFF
--- a/notebook/_version.py
+++ b/notebook/_version.py
@@ -9,5 +9,5 @@ store the current version info of the notebook.
 
 # Next beta/alpha/rc release: The version number for beta is X.Y.ZbN **without dots**.
 
-version_info = (5, 0, 0, 5)
+version_info = (5, 0, 0, 6)
 __version__ = '.'.join(map(str, version_info))

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -682,9 +682,9 @@ define([
 
         // directory nav doesn't open new tabs
         // files, notebooks do
-        if (model.type !== "directory") {
-            link.attr('target',IPython._target);
-        }
+        // if (model.type !== "directory") {
+        //     link.attr('target',IPython._target);
+        // }
 
         // Add in the date that the file was last modified
         item.find(".item_modified").text(moment.utc(modified).fromNow());

--- a/notebook/templates/page.html
+++ b/notebook/templates/page.html
@@ -194,6 +194,7 @@
   </div>
 </noscript>
 
+{% block full_header %}
 <div id="header">
   <div id="header-container" class="container">
   <div id="ipython_notebook" class="nav navbar-brand pull-left"><a href="{{default_url}}" title='dashboard'>{% block logo %}<img src='{{static_url("base/images/logo.png") }}' alt='Jupyter Notebook'/>{% endblock %}</a></div>
@@ -222,6 +223,7 @@
   {% block header %}
   {% endblock %}
 </div>
+{% endblock %}
 
 <div id="site">
 {% block site %}

--- a/notebook/templates/tree.html
+++ b/notebook/templates/tree.html
@@ -10,6 +10,7 @@ data-notebook-path="{{notebook_path | urlencode}}"
 data-terminals-available="{{terminals_available}}"
 {% endblock %}
 
+{% block full_header %} {% endblock %}
 
 {% block site %}
 


### PR DESCRIPTION
This PR adds a very minor change which hides the header from the tree view. This removes the ability to click on `control panel` in the upper corner but that functionality will get move to the `resources` tab when the marathon spawner's ready.