### PR TITLE
Fix links for notebook spawner notebooks in local dev

### DIFF
--- a/notebook/static/tree/js/newnotebook.js
+++ b/notebook/static/tree/js/newnotebook.js
@@ -93,7 +93,7 @@ define([
                     );
                     url = "https://" +  window.location.hostname + "/" + url;
                 }
-                else if(window.location.hostname.includes("localhost") && window.location.port != "8888") {
+                else if(window.location.hostname.includes("localhost")) {
                     var hard_coded_notebook_spawner_port = 8282;
                     url = utils.url_path_join(
                         "notebooks",
@@ -101,7 +101,7 @@ define([
                         "notebooks",
                         utils.encode_uri_components(data.path)
                     );
-                    url = window.location.hostname + ":" + hard_coded_notebook_spawner_port + "/" + url;
+                    url = "http://" + window.location.hostname + ":" + hard_coded_notebook_spawner_port + "/" + url;
                 }
 
                 if (kernel_name) {

--- a/notebook/static/tree/js/newnotebook.js
+++ b/notebook/static/tree/js/newnotebook.js
@@ -84,9 +84,18 @@ define([
                     utils.encode_uri_components(data.path)
                 );
 
-
+                if (window.location.hostname.contains("localhost")) {
+                    var url = utils.url_path_join(
+                        window.location.hostname,
+                        ":",
+                        window.location.port,
+                        window.location.pathname,
+                        'notebooks',
+                        utils.encode_uri_components(data.path)
+                    );
+                }
                 // if we are running this in a production environment
-                if (window.location.hostname.contains('datascience.com')) {
+                else if (window.location.hostname.contains('datascience.com')) {
                     url = utils.url_path_join(
                         "notebooks",
                         "tree",

--- a/notebook/static/tree/js/newnotebook.js
+++ b/notebook/static/tree/js/newnotebook.js
@@ -86,9 +86,8 @@ define([
 
 
                 // if we are running this in a production environment
-                if (window.location.pathname.startsWith('/app/jupyter-')) {
+                if (window.location.hostname.contains('datascience.com')) {
                     url = utils.url_path_join(
-                        that.base_url,
                         "notebooks",
                         "tree",
                         "notebooks",

--- a/notebook/static/tree/js/newnotebook.js
+++ b/notebook/static/tree/js/newnotebook.js
@@ -80,23 +80,29 @@ define([
         this.contents.new_untitled(that.notebook_path, {type: "notebook"}).then(
             function (data) {
                 var url = utils.url_path_join(
-                    that.base_url, 'notebooks',
+                    that.base_url, 'notebooks-breaking-test',
                     utils.encode_uri_components(data.path)
                 );
 
                 if (window.location.hostname.contains("localhost")) {
                     // hackzilla
+                    try {
                     var url = utils.url_path_join(
                         document.getElementById("iframe_id").src,
                         utils.encode_uri_components(data.path)
                     );
+                    }
+                    catch(err) {
+                        // this implies local but no iframe was found.
+                        // default to vanilla Jupyter url.
+                    }
                 }
                 // if we are running this in a production environment
                 else if (window.location.hostname.contains('datascience.com')) {
                     url = utils.url_path_join(
                         "notebooks",
                         "tree",
-                        "notebooks",
+                        "notebooks-breaking-test",
                         utils.encode_uri_components(data.path)
                     )
                 }

--- a/notebook/static/tree/js/newnotebook.js
+++ b/notebook/static/tree/js/newnotebook.js
@@ -80,38 +80,34 @@ define([
         this.contents.new_untitled(that.notebook_path, {type: "notebook"}).then(
             function (data) {
                 var url = utils.url_path_join(
-                    that.base_url, 'notebooks-breaking-test',
+                    that.base_url, 'notebooks',
                     utils.encode_uri_components(data.path)
                 );
-
-                if (window.location.hostname.contains("localhost")) {
-                    // hackzilla
-                    try {
-                    var url = utils.url_path_join(
-                        document.getElementById("iframe_id").src,
-                        utils.encode_uri_components(data.path)
-                    );
-                    }
-                    catch(err) {
-                        // this implies local but no iframe was found.
-                        // default to vanilla Jupyter url.
-                    }
-                }
                 // if we are running this in a production environment
-                else if (window.location.hostname.contains('datascience.com')) {
+                if (window.location.hostname.includes('datascience.com')) {
                     url = utils.url_path_join(
                         "notebooks",
                         "tree",
-                        "notebooks-breaking-test",
+                        "notebooks",
                         utils.encode_uri_components(data.path)
-                    )
+                    );
+                    url = "https://" +  window.location.hostname + "/" + url;
+                }
+                else if(window.location.hostname.includes("localhost") && window.location.port != "8888") {
+                    var hard_coded_notebook_spawner_port = 8282;
+                    url = utils.url_path_join(
+                        "notebooks",
+                        "tree",
+                        "notebooks",
+                        utils.encode_uri_components(data.path)
+                    );
+                    url = window.location.hostname + ":" + hard_coded_notebook_spawner_port + "/" + url;
                 }
 
                 if (kernel_name) {
                     url += "?kernel_name=" + kernel_name;
-                }
-                var finalURL = "https://" + window.location.hostname + "/" + url;
-                w.location = finalURL;
+	              }
+                w.location = url;
         }).catch(function (e) {
             w.close();
             dialog.modal({

--- a/notebook/static/tree/js/newnotebook.js
+++ b/notebook/static/tree/js/newnotebook.js
@@ -88,6 +88,7 @@ define([
                 // if we are running this in a production environment
                 if (window.location.pathname.startsWith('/app/jupyter-')) {
                     url = utils.url_path_join(
+                        that.base_url,
                         "notebooks",
                         "tree",
                         "notebooks",

--- a/notebook/static/tree/js/newnotebook.js
+++ b/notebook/static/tree/js/newnotebook.js
@@ -85,12 +85,9 @@ define([
                 );
 
                 if (window.location.hostname.contains("localhost")) {
+                    // hackzilla
                     var url = utils.url_path_join(
-                        window.location.hostname,
-                        ":",
-                        window.location.port,
-                        window.location.pathname,
-                        'notebooks',
+                        document.getElementById("iframe_id").src,
                         utils.encode_uri_components(data.path)
                     );
                 }

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -689,18 +689,35 @@ define([
             link.attr('target',IPython._target);
 
             // if we are opening the link in a production environment
-            if (window.location.pathname.startsWith('/app/jupyter-')) {
+            if (window.location.hostname.includes("datascience.com")) {
                 // get the path after the jupyter link
-                var newPath = utils.url_path_join(
-                    window.location.hostname,
+                var new_path = utils.url_path_join(
                     "notebooks",
                     "tree",
                     uri_prefix,
                     utils.encode_uri_components(path)
-                )
+                );
                 // make sure the protocol is there
-                link.attr('href', "https://" + newPath)
-           }
+                link.attr('href', "https://" + window.location.hostname + "/" + newPath);
+             }
+            else if (window.location.hostname.includes("localhost")
+                     && window.location.port != "8888"
+              ) {
+                // get the path after the jupyter link
+              var hard_coded_notebook_spawner_port = "8282";
+              var new_path = utils.url_path_join(
+                "notebooks",
+                "tree",
+                uri_prefix,
+                utils.encode_uri_components(path)
+              );
+                // make sure the protocol is there
+                link.attr('href',
+                          window.location.hostname + ":" + hard_coded_notebooks_spawner_port +
+                          "/" + new_path
+                );
+            }
+
         }
 
         // Add in the date that the file was last modified

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -700,9 +700,7 @@ define([
                 // make sure the protocol is there
                 link.attr('href', "https://" + window.location.hostname + "/" + newPath);
              }
-            else if (window.location.hostname.includes("localhost")
-                     && window.location.port != "8888"
-              ) {
+            else if (window.location.hostname.includes("localhost")) {
                 // get the path after the jupyter link
               var hard_coded_notebook_spawner_port = "8282";
               var new_path = utils.url_path_join(
@@ -711,9 +709,8 @@ define([
                 uri_prefix,
                 utils.encode_uri_components(path)
               );
-                // make sure the protocol is there
                 link.attr('href',
-                          window.location.hostname + ":" + hard_coded_notebooks_spawner_port +
+                          "http://" + window.location.hostname + ":" + hard_coded_notebooks_spawner_port +
                           "/" + new_path
                 );
             }

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -702,7 +702,7 @@ define([
              }
             else if (window.location.hostname.includes("localhost")) {
                 // get the path after the jupyter link
-              var hard_coded_notebook_spawner_port = "8282";
+              var nb_spawner_port = "8282";
               var new_path = utils.url_path_join(
                 "notebooks",
                 "tree",
@@ -710,7 +710,7 @@ define([
                 utils.encode_uri_components(path)
               );
                 link.attr('href',
-                          "http://" + window.location.hostname + ":" + hard_coded_notebooks_spawner_port +
+                          "http://" + window.location.hostname + ":" + nb_spawner_port +
                           "/" + new_path
                 );
             }

--- a/notebook/static/tree/js/terminallist.js
+++ b/notebook/static/tree/js/terminallist.js
@@ -107,9 +107,8 @@ define([
             var link = item.find("a.item_link")
                 .attr('href', terminal_link_path);
         }
-        else if (window.location.hostname.includes("localhost")
-                 && window.location.port != "8888"
-                ) {
+        else if (window.location.hostname.includes("localhost")) {
+            var hardcoded_spawner_port = "8282";
             var terminal_link_base_path = utils.url_path_join(
                 "notebooks",
                 "tree",
@@ -117,7 +116,7 @@ define([
                 utils.encode_uri_components(name)
             );
             var terminal_link_path =
-                window.location.hostname + ":" + window.location.port +  "/" +
+                "http://" + window.location.hostname + ":" + hardcoded_spawner_port +  "/" +
                   terminal_link_base_path;
             var link = item.find("a.item_link")
                 .attr('href', terminal_link_path);

--- a/notebook/static/tree/js/terminallist.js
+++ b/notebook/static/tree/js/terminallist.js
@@ -42,14 +42,38 @@ define([
 
     TerminalList.prototype.new_terminal = function () {
         var w = window.open(undefined, IPython._target);
-        var base_url = this.base_url;
         var settings = {
             type : "POST",
             dataType: "json",
             success : function (data, status, xhr) {
                 var name = data.name;
-                w.location = utils.url_path_join(base_url, 'terminals', 
-                    utils.encode_uri_components(name));
+        var terminal_link_path;
+        // Production fix
+        if (window.location.hostname.includes("datascience.com")) {
+            var terminal_link_base_path = utils.url_path_join(
+                "notebooks",
+                "tree",
+                "terminals",
+                utils.encode_uri_components(name)
+            );
+            terminal_link_path =
+                "https://" + window.location.hostname + "/" + terminal_link_base_path;
+        }
+        else if (window.location.hostname.includes("localhost")) {
+            var hardcoded_spawner_port = "8282";
+            var terminal_link_base_path = utils.url_path_join(
+                "notebooks",
+                "tree",
+                "terminals",
+                utils.encode_uri_components(name)
+            );
+            terminal_link_path =
+                "http://" + window.location.hostname + ":" + hardcoded_spawner_port +  "/" +
+                  terminal_link_base_path;
+        }
+
+
+                w.location = terminal_link_path;
             },
             error : function(jqXHR, status, error){
                 w.close();
@@ -94,34 +118,6 @@ define([
         var link = item.find("a.item_link")
             .attr('href', utils.url_path_join(this.base_url, "terminals",
                                               utils.encode_uri_components(name)));
-        // Production fix
-        if (window.location.hostname.includes("datascience.com")) {
-            var terminal_link_base_path = utils.url_path_join(
-                "notebooks",
-                "tree",
-                "terminals",
-                utils.encode_uri_components(name)
-            );
-            var terminal_link_path =
-                "https://" + window.location.hostname + "/" + terminal_link_base_path;
-            var link = item.find("a.item_link")
-                .attr('href', terminal_link_path);
-        }
-        else if (window.location.hostname.includes("localhost")) {
-            var hardcoded_spawner_port = "8282";
-            var terminal_link_base_path = utils.url_path_join(
-                "notebooks",
-                "tree",
-                "terminals",
-                utils.encode_uri_components(name)
-            );
-            var terminal_link_path =
-                "http://" + window.location.hostname + ":" + hardcoded_spawner_port +  "/" +
-                  terminal_link_base_path;
-            var link = item.find("a.item_link")
-                .attr('href', terminal_link_path);
-        }
-
 
 
         link.attr('target', IPython._target||'_blank');

--- a/notebook/static/tree/js/terminallist.js
+++ b/notebook/static/tree/js/terminallist.js
@@ -93,7 +93,38 @@ define([
         item.find(".item_icon").addClass("fa fa-terminal");
         var link = item.find("a.item_link")
             .attr('href', utils.url_path_join(this.base_url, "terminals",
-                utils.encode_uri_components(name)));
+                                              utils.encode_uri_components(name)));
+        // Production fix
+        if (window.location.hostname.includes("datascience.com")) {
+            var terminal_link_base_path = utils.url_path_join(
+                "notebooks",
+                "tree",
+                "terminals",
+                utils.encode_uri_components(name)
+            );
+            var terminal_link_path =
+                "https://" + window.location.hostname + "/" + terminal_link_base_path;
+            var link = item.find("a.item_link")
+                .attr('href', terminal_link_path);
+        }
+        else if (window.location.hostname.includes("localhost")
+                 && window.location.port != "8888"
+                ) {
+            var terminal_link_base_path = utils.url_path_join(
+                "notebooks",
+                "tree",
+                "terminals",
+                utils.encode_uri_components(name)
+            );
+            var terminal_link_path =
+                window.location.hostname + ":" + window.location.port +  "/" +
+                  terminal_link_base_path;
+            var link = item.find("a.item_link")
+                .attr('href', terminal_link_path);
+        }
+
+
+
         link.attr('target', IPython._target||'_blank');
         this.add_shutdown_button(name, item);
     };


### PR DESCRIPTION
Links are not being generated correctly for notebooks viewed in notebook spawner on localhost

This issue effects:

- [ ] opening a new notebook (partially fixed) 
https://github.com/datascienceinc/notebooks-singleuser/issues/71
- The  changes I've made to `newnotebook.js` generate the correct url, but for some reason Jupyter opens a blank tab.  Once this blank tab issue is debugged this portion should be fixed.
- [ ] opening a notebook: 
Looks like:
  <img width="500" alt="screen shot 2016-11-19 at 3 43 47 pm"    src="https://cloud.githubusercontent.com/assets/8229560/20459242/071b1194-ae6f-11e6-9b31-ee56bc4a984d.png">
  <br>
  Should look like:
  <br>
  <img width="476" alt="screen shot 2016-11-19 at 3 45 48 pm" src="https://cloud.githubusercontent.com/assets/8229560/20459254/43acb248-ae6f-11e6-97c9-dddecbf02d7d.png">
  <br>

- [ ] opening a terminal

Looks like:
<br>
<img width="442" alt="screen shot 2016-11-19 at 3 46 54 pm" src="https://cloud.githubusercontent.com/assets/8229560/20459262/852f1bf2-ae6f-11e6-8372-ccaf5a1a6bea.png">
<br>
Should look like:
<br>
<img width="493" alt="screen shot 2016-11-19 at 3 47 13 pm" src="https://cloud.githubusercontent.com/assets/8229560/20459263/9aa16d8c-ae6f-11e6-8902-8edf94881180.png">
<br>
<br>
