### PR TITLE
Tree download button should now work to download ipynb file

### DIFF
--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -925,10 +925,24 @@ define([
         if (that.selected.length !== 1){
             return;
         }
+        function build_path(s1, s2) {
+            return s1 + "/" + s2;
+        };
 
         var item_path = that.selected[0].path;
+        var split_path_nblist = window.location.pathname.split("/");
 
-        window.open(utils.url_path_join('/files', item_path) + '?download=1');
+        // Warning! This change assumes that the path will be like '/app/jupyter-<user>/...'
+        //window.open(utils.url_path_join('/files', item_path) + '?download=1');
+        window.open(
+          [
+            window.location.origin,
+            split_path_nblist[1],
+            split_path_nblist[2],
+            "files",
+            item_path
+           ].reduce(build_path) + "?download=1"
+        );
     };
 
     NotebookList.prototype.delete_selected = function() {


### PR DESCRIPTION
Changes the JS download link to where is should exit on our system.  This works locally but still needs to be tested against preview.

https://github.com/datascienceinc/notebooks-singleuser/issues/84