### PR TITLE
fixed invalid dates on checkpoint-created & checkpoint-saved

### DIFF
--- a/notebook/static/notebook/js/notificationarea.js
+++ b/notebook/static/notebook/js/notificationarea.js
@@ -6,16 +6,16 @@ define([
 ], function(utils, dialog, notificationarea, moment) {
     "use strict";
     var NotificationArea = notificationarea.NotificationArea;
-    
+
     var NotebookNotificationArea = function(selector, options) {
         NotificationArea.apply(this, [selector, options]);
         this.save_widget = options.save_widget;
         this.notebook = options.notebook;
         this.keyboard_manager = options.keyboard_manager;
     };
-    
+
     NotebookNotificationArea.prototype = Object.create(NotificationArea.prototype);
-    
+
     /**
      * Initialize the default set of notification widgets.
      *
@@ -196,7 +196,7 @@ define([
 
             showMsg();
         });
-        
+
         this.events.on("no_kernel.Kernel", function (evt, data) {
             $("#kernel_indicator").find('.kernel_indicator_name').text("No Kernel");
         });
@@ -271,7 +271,7 @@ define([
             });
         });
 
-        
+
         // Start the kernel indicator in the busy state, and send a kernel_info request.
         // When the kernel_info reply arrives, the kernel is idle.
         $kernel_ind_icon.attr('class','kernel_busy_icon').attr('title','Kernel Busy');
@@ -304,12 +304,12 @@ define([
         this.events.on('notebook_copy_failed.Notebook', function (evt, error) {
             nnw.warning(error.message || "Notebook copy failed");
         });
-        
+
         // Checkpoint events
         this.events.on('checkpoint_created.Notebook', function (evt, data) {
             var msg = "Checkpoint created";
             if (data.last_modified) {
-                var d = new Date(data.last_modified);
+                var d = moment.utc(data.last_modified, "YYYY-MM-DD HH:mm:ss.S").toDate()
                 msg = msg + ": " + moment(d).format("HH:mm:ss");
             }
             nnw.set_message(msg, 2000);

--- a/notebook/static/notebook/js/savewidget.js
+++ b/notebook/static/notebook/js/savewidget.js
@@ -156,16 +156,16 @@ define([
 
     SaveWidget.prototype._set_last_checkpoint = function (checkpoint) {
         if (checkpoint) {
-            this._checkpoint_date = new Date(checkpoint.last_modified);
+            this._checkpoint_date = moment.utc(checkpoint.last_modified, "YYYY-MM-DD HH:mm:ss.S").toDate();
         } else {
             this._checkpoint_date = null;
         }
         this._render_checkpoint();
     };
-    
+
     SaveWidget.prototype._render_checkpoint = function () {
         /** actually set the text in the element, from our _checkpoint value
-        
+
         called directly, and periodically in timeouts.
         */
         this._schedule_render_checkpoint();
@@ -182,17 +182,17 @@ define([
             // less than 24 hours old, use relative date
             human_date = chkd.fromNow();
         } else {
-            // otherwise show calendar 
+            // otherwise show calendar
             // <Today | yesterday|...> at hh,mm,ss
             human_date = chkd.calendar();
         }
         el.text('Last Checkpoint: ' + human_date).attr('title', long_date);
     };
 
-    
+
     SaveWidget.prototype._schedule_render_checkpoint = function () {
         /** schedule the next update to relative date
-        
+
         periodically updated, so short values like 'a few seconds ago' don't get stale.
         */
         if (!this._checkpoint_date) {


### PR DESCRIPTION
Addresses the invalid date issue that appears on the `Last checkpoint: ` & `Last saved: ` messages in Safari and Firefox

https://github.com/datascienceinc/notebooks-api/issues/66