### PR TITLE
Fix rebroken tree view download button

### DIFF
--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -938,15 +938,14 @@ define([
         };
 
         var item_path = that.selected[0].path;
-        var split_path_nblist = window.location.pathname.split("/");
 
-        // Warning! This change assumes that the path will be like '/app/jupyter-<user>/...'
         //window.open(utils.url_path_join('/files', item_path) + '?download=1');
+
+        // Datascience specific 
         window.open(
           [
             window.location.origin,
-            split_path_nblist[1],
-            split_path_nblist[2],
+            $('iframe, body').attr('data-base-url'),
             "files",
             item_path
            ].reduce(build_path) + "?download=1"

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -933,9 +933,6 @@ define([
         if (that.selected.length !== 1){
             return;
         }
-        function build_path(s1, s2) {
-            return s1 + "/" + s2;
-        };
 
         var item_path = that.selected[0].path;
 
@@ -943,12 +940,12 @@ define([
 
         // Datascience specific 
         window.open(
-          [
-            window.location.origin,
-            $('iframe, body').attr('data-base-url'),
-            "files",
-            item_path
-           ].reduce(build_path) + "?download=1"
+          window.location.origin +
+          $('iframe, body').attr('data-base-url') +
+          "files" + 
+          "/" +
+          item_path +
+          "?download=1"
         );
     };
 


### PR DESCRIPTION
This a second fix for the tree view download button.  I noticed today that my last fix seems to have broken in preview in some reason.

![screen shot 2016-12-02 at 2 40 15 pm](https://cloud.githubusercontent.com/assets/8229560/20852876/43670b52-b89d-11e6-964b-3d241bead3c9.png)

This version gets the notebook base path from the iframe via jquery and should be less likely to break again. This version works locally but needs to be tested in preview.